### PR TITLE
Add handling for a resize event

### DIFF
--- a/include/imgui-ws/imgui-ws.h
+++ b/include/imgui-ws/imgui-ws.h
@@ -35,6 +35,7 @@ class ImGuiWS {
                 KeyPress,
                 KeyDown,
                 KeyUp,
+                Resize,
             };
 
             Type type = Unknown;
@@ -50,6 +51,9 @@ class ImGuiWS {
             int32_t mouse_but = 0;
 
             int32_t key = 0;
+
+            int32_t client_width = 1920;
+            int32_t client_height = 1080;
 
             std::string ip;
         };

--- a/src/imgui-ws.cpp
+++ b/src/imgui-ws.cpp
@@ -204,6 +204,13 @@ bool ImGuiWS::init(int32_t port, const char * pathHttp) {
                                 ss >> event.key;
                             }
                             break;
+                        case 7:
+                            {
+                                // resize
+                                event.type = Event::Resize;
+                                ss >> event.client_width >> event.client_height;
+                            }
+                            break;
                         default:
                             {
                                 printf("Unknown input received from client: id = %d, type = %d\n", clientId, type);


### PR DESCRIPTION
If the front end allows the canvas to be resized, then imgui needs to know about this. This PR wires up that data so it can be used by imgui.