### PR TITLE
Expose incppects var function

### DIFF
--- a/include/imgui-ws/imgui-ws.h
+++ b/include/imgui-ws/imgui-ws.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <functional>
 #include <vector>
 #include <queue>
 #include <string>
@@ -13,6 +14,10 @@
 class ImGuiWS {
     public:
         using TextureId = uint32_t;
+
+        using TPath = std::string;
+        using TIdxs = std::vector<int>;
+        using TGetter = std::function<std::string_view(const TIdxs & idxs)>;
 
         struct Texture {
             enum Type : int32_t {
@@ -60,6 +65,7 @@ class ImGuiWS {
         bool init(int32_t port, const char * pathHttp);
         bool setTexture(TextureId textureId, int32_t width, int32_t height, const char * data);
         bool setDrawData(const struct ImDrawData * drawData);
+        bool addVar(const TPath & path, TGetter && getter);
 
         int32_t nConnected() const;
 

--- a/src/imgui-ws.cpp
+++ b/src/imgui-ws.cpp
@@ -69,6 +69,10 @@ ImGuiWS::~ImGuiWS() {
     }
 }
 
+bool ImGuiWS::addVar(const TPath & path, TGetter && getter) {
+    return m_impl->incpp.var(path, std::move(getter));
+}
+
 bool ImGuiWS::init(int32_t port, const char * pathHttp) {
     m_impl->incpp.var("my_id[%d]", [](const auto & idxs) {
         static int32_t id;


### PR DESCRIPTION
In applications where ImGuiWS is being used as a library, it is useful to expose the `incppect::var` function so we can add new callbacks at runtime.