### PR TITLE
Expose incppects stop function

### DIFF
--- a/include/imgui-ws/imgui-ws.h
+++ b/include/imgui-ws/imgui-ws.h
@@ -60,6 +60,7 @@ class ImGuiWS {
         bool init(int32_t port, const char * pathHttp);
         bool setTexture(TextureId textureId, int32_t width, int32_t height, const char * data);
         bool setDrawData(const struct ImDrawData * drawData);
+        void stop();
 
         int32_t nConnected() const;
 

--- a/src/imgui-ws.cpp
+++ b/src/imgui-ws.cpp
@@ -69,6 +69,10 @@ ImGuiWS::~ImGuiWS() {
     }
 }
 
+void ImGuiWS::stop() {
+    m_impl->incpp.stop();
+}
+
 bool ImGuiWS::init(int32_t port, const char * pathHttp) {
     m_impl->incpp.var("my_id[%d]", [](const auto & idxs) {
         static int32_t id;


### PR DESCRIPTION
In applications where ImGuiWS is being used as a library, it's useful to expose `incppect::stop` so we can manage it through ImGuiWS.