### PR TITLE
Add connect and disconnect callbacks

### DIFF
--- a/include/imgui-ws/imgui-ws.h
+++ b/include/imgui-ws/imgui-ws.h
@@ -15,6 +15,7 @@ class ImGuiWS {
     public:
         using TextureId = uint32_t;
 
+        using THandler = std::function<void()>;
         using TPath = std::string;
         using TIdxs = std::vector<int>;
         using TGetter = std::function<std::string_view(const TIdxs & idxs)>;
@@ -70,9 +71,11 @@ class ImGuiWS {
         ~ImGuiWS();
 
         bool init(int32_t port, const char * pathHttp);
+        bool init(int32_t port, const char * pathHttp, const THandler & connect_handler, const THandler & disconnect_handler);
         bool setTexture(TextureId textureId, Texture::Type textureType, int32_t width, int32_t height, const char * data);
         bool setDrawData(const struct ImDrawData * drawData);
         bool addVar(const TPath & path, TGetter && getter);
+
 
         int32_t nConnected() const;
 
@@ -81,4 +84,8 @@ class ImGuiWS {
     private:
         struct Impl;
         std::unique_ptr<Impl> m_impl;
+        THandler connect_handler = nullptr;
+        THandler disconnect_handler = nullptr;
+        void registerHandlerConnect(const THandler & handler);
+        void registerHandlerDisconnect(const THandler & handler);
 };

--- a/src/imgui-ws.cpp
+++ b/src/imgui-ws.cpp
@@ -167,12 +167,18 @@ bool ImGuiWS::init(int32_t port, const char * pathHttp) {
                     { int a = data[2]; if (a < 0) a += 256; ss << a << "."; }
                     { int a = data[3]; if (a < 0) a += 256; ss << a; }
                     event.ip = ss.str();
+                    if (connect_handler) {
+                        connect_handler();
+                    }
                 }
                 break;
             case incppect::Disconnect:
                 {
                     --m_impl->nConnected;
                     event.type = Event::Disconnected;
+                    if (disconnect_handler) {
+                        disconnect_handler();
+                    }
                 }
                 break;
             case incppect::Custom:
@@ -315,6 +321,12 @@ bool ImGuiWS::setTexture(TextureId textureId, Texture::Type textureType, int32_t
     return true;
 }
 
+bool ImGuiWS::init(int32_t port, const char * pathHttp, const THandler & connect_handler, const THandler & disconnect_handler) {
+    registerHandlerConnect(connect_handler);
+    registerHandlerDisconnect(disconnect_handler);
+    return init(port, pathHttp);
+}
+
 bool ImGuiWS::setDrawData(const ImDrawData * drawData) {
     bool result = true;
 
@@ -342,4 +354,12 @@ std::deque<ImGuiWS::Event> ImGuiWS::takeEvents() {
     std::lock_guard<std::mutex> lock(m_impl->events.mutex);
     auto res = std::move(m_impl->events.data);
     return res;
+}
+
+void ImGuiWS::registerHandlerConnect(const THandler & handler) {
+    connect_handler = std::move(handler);
+}
+
+void ImGuiWS::registerHandlerDisconnect(const THandler & handler) {
+    disconnect_handler = std::move(handler);
 }


### PR DESCRIPTION
Allowing the calling application to be notified of connects and disconnects simplifies logic around these events. Previously, the only solution was a busy loop which called `takeEvents()`, requiring a separate thread if the main thread needed to do other work. This solution allows these events to propagate asynchronously. These handlers were not added to `Incppect` because they would be called through the `ImGuiWS` class anyway and `Incppect` makes these events available to `ImGuiWS`. Additionally, if `ImGuiWS` is not being used to render frames but instead as a proxy for `Incppect`, this again simplifies the logic needed to respond to these events.