### PR TITLE
Add TakeControl event

### DIFF
--- a/include/imgui-ws/imgui-ws.h
+++ b/include/imgui-ws/imgui-ws.h
@@ -45,6 +45,7 @@ class ImGuiWS {
                 KeyDown,
                 KeyUp,
                 Resize,
+                TakeControl,
             };
 
             Type type = Unknown;

--- a/src/imgui-ws.cpp
+++ b/src/imgui-ws.cpp
@@ -254,6 +254,12 @@ bool ImGuiWS::init(int32_t port, const char * pathHttp) {
                                 ss >> event.client_width >> event.client_height;
                             }
                             break;
+                        case 8:
+                            {
+                                // take control
+                                event.type = Event::TakeControl;
+                            }
+                            break;
                         default:
                             {
                                 printf("Unknown input received from client: id = %d, type = %d\n", clientId, type);


### PR DESCRIPTION
This is a simple addition to the events list which could allow a client to send a TakeControl event to the server.  The server could handle this request by giving mouse control to that client and rendering the window size of that client.