### PR TITLE
Enable 32-bit vertex indices

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -158,6 +158,11 @@ var imgui_ws = {
         this.gl.vertexAttribPointer(this.attribute_location_position, 2, this.gl.FLOAT,         false, 5*4, 0);
         this.gl.vertexAttribPointer(this.attribute_location_uv,       2, this.gl.FLOAT,         false, 5*4, 2*4);
         this.gl.vertexAttribPointer(this.attribute_location_color,    4, this.gl.UNSIGNED_BYTE, true,  5*4, 4*4);
+
+        // enable 32-bit vertex indices
+        if (this.gl.getExtension('OES_element_index_uint') == null) {
+            throw new Error('WebGL: OES_element_index_uint is not supported');
+        }
     },
 
     incppect_textures: function(incppect) {
@@ -292,10 +297,10 @@ var imgui_ws = {
             p = new Uint32Array(draw_lists_abuf[i_list], draw_data_offset, 1);
             var n_indices = p[0]; draw_data_offset += 4;
 
-            var ai = new Uint16Array(draw_lists_abuf[i_list], draw_data_offset, n_indices);
+            var ai = new Uint32Array(draw_lists_abuf[i_list], draw_data_offset, n_indices);
             this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, this.index_buffer);
             this.gl.bufferData(this.gl.ELEMENT_ARRAY_BUFFER, ai, this.gl.STREAM_DRAW);
-            draw_data_offset += 2*n_indices;
+            draw_data_offset += 4*n_indices;
 
             p = new Uint32Array(draw_lists_abuf[i_list], draw_data_offset, 1);
             var n_cmd = p[0]; draw_data_offset += 4;
@@ -319,7 +324,7 @@ var imgui_ws = {
                         this.gl.activeTexture(this.gl.TEXTURE0);
                         this.gl.bindTexture(this.gl.TEXTURE_2D, this.tex_map_id[texture_id]);
                     }
-                    this.gl.drawElements(this.gl.TRIANGLES, n_elements, this.gl.UNSIGNED_SHORT, 2*offset_idx);
+                    this.gl.drawElements(this.gl.TRIANGLES, n_elements, this.gl.UNSIGNED_INT, 4*offset_idx);
                 }
             }
         }

--- a/src/compressor-xor-rle-per-draw-list-with-vtx-offset.cpp
+++ b/src/compressor-xor-rle-per-draw-list-with-vtx-offset.cpp
@@ -41,7 +41,7 @@ void writeCmdListToBuffer(const ImDrawList * cmdList, std::vector<char> & buf) {
     std::copy((char *)(cmdList->IdxBuffer.Data), (char *)(cmdList->IdxBuffer.Data) + nIndicesOriginal*sizeof(ImDrawIdx), std::back_inserter(buf));
 
     if (nIndicesOriginal % 2 == 1) {
-        uint16_t idx = 0;
+        ImDrawIdx idx = 0;
         std::copy((char *)(&idx), (char *)(&idx) + sizeof(idx), std::back_inserter(buf));
     }
 

--- a/src/imgui-ws.js
+++ b/src/imgui-ws.js
@@ -148,6 +148,11 @@ var imgui_ws = {
         this.gl.vertexAttribPointer(this.attribute_location_position, 2, this.gl.FLOAT,         false, 5*4, 0);
         this.gl.vertexAttribPointer(this.attribute_location_uv,       2, this.gl.FLOAT,         false, 5*4, 2*4);
         this.gl.vertexAttribPointer(this.attribute_location_color,    4, this.gl.UNSIGNED_BYTE, true,  5*4, 4*4);
+
+        // enable 32-bit vertex indices
+        if (this.gl.getExtension('OES_element_index_uint') == null) {
+            throw new Error('WebGL: OES_element_index_uint is not supported');
+        }
     },
 
     incppect_textures: function(incppect) {
@@ -282,10 +287,10 @@ var imgui_ws = {
             p = new Uint32Array(draw_lists_abuf[i_list], draw_data_offset, 1);
             var n_indices = p[0]; draw_data_offset += 4;
 
-            var ai = new Uint16Array(draw_lists_abuf[i_list], draw_data_offset, n_indices);
+            var ai = new Uint32Array(draw_lists_abuf[i_list], draw_data_offset, n_indices);
             this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, this.index_buffer);
             this.gl.bufferData(this.gl.ELEMENT_ARRAY_BUFFER, ai, this.gl.STREAM_DRAW);
-            draw_data_offset += 2*n_indices;
+            draw_data_offset += 4*n_indices;
 
             p = new Uint32Array(draw_lists_abuf[i_list], draw_data_offset, 1);
             var n_cmd = p[0]; draw_data_offset += 4;
@@ -309,7 +314,7 @@ var imgui_ws = {
                         this.gl.activeTexture(this.gl.TEXTURE0);
                         this.gl.bindTexture(this.gl.TEXTURE_2D, this.tex_map_id[texture_id]);
                     }
-                    this.gl.drawElements(this.gl.TRIANGLES, n_elements, this.gl.UNSIGNED_SHORT, 2*offset_idx);
+                    this.gl.drawElements(this.gl.TRIANGLES, n_elements, this.gl.UNSIGNED_INT, 4*offset_idx);
                 }
             }
         }

--- a/third-party/imgui/imgui-extra/imconfig-vtx32.h
+++ b/third-party/imgui/imgui-extra/imconfig-vtx32.h
@@ -61,7 +61,7 @@
 */
 
 //---- Use 32-bit vertex indices (default is 16-bit) to allow meshes with more than 64K vertices. Render function needs to support it.
-//#define ImDrawIdx unsigned int
+#define ImDrawIdx unsigned int
 
 //---- Tip: You can add extra functions within the ImGui:: namespace, here or in your own headers files.
 /*


### PR DESCRIPTION
ref #5 

- This change enables 32-bit vertex indices in Dear ImGui and also makes the WebGL renderer use 32-bit vertex arrays 
- Your browser must support the [OES_element_index_uint](https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/) extension in order to run this
- After checking out this branch, make sure to remove `CMakeCache.txt` from your build folder and re-build the project

For now, I don't want to merge this into `master` yet, because I am not sure how many devices support this WebGL extension.
Maybe we need to add some fallback logic if it is not supported.